### PR TITLE
[FIX #9]1-actor::n-exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- 🚀 [2017-05-09] `engine/containers/numberGenerator`: update to v3.0.0.
+  - 🚀 New generator parameter & property: `finalPosition`. It will be used by the engine to check if the actual exit is the correct one.
 - 🚀 [2017-05-09] `gameMetadata`: update to v4.1.0.
   - 🚀 Add new property: `actorsPositions`: will define what access and what exit are for which actor.
 - 🐛 [2017-05-07] `engine/containers/mazeEngineGenerator`: update to v3.0.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- 🚀 [2017-05-09] `gameMetadata`: update to v4.1.0.
+  - 🚀 Add new property: `actorsPositions`: will define what access and what exit are for which actor.
 - 🐛 [2017-05-07] `engine/containers/mazeEngineGenerator`: update to v3.0.1.
   - 🐛 Fix #8. It validate path AND walls.
   - ✅ Add new test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## HEAD
 
+- 🚀 [2017-05-09] `engine/containers/mazeEngineGenerator`: update to v3.1.0.
+  - 🚀 Add new validation with new error type (`MazeWrongExitError`) for `numberHasLeftMaze`. This will be thrown if the actual actor's exit is wrong.
+  - 🚀 Update `handleResetGame` to match the new `gameMetadata` prop & how actor-exit relation works now.
 - 🚀 [2017-05-09] `engine/containers/numberGenerator`: update to v3.0.0.
   - 🚀 New generator parameter & property: `finalPosition`. It will be used by the engine to check if the actual exit is the correct one.
 - 🚀 [2017-05-09] `gameMetadata`: update to v4.1.0.

--- a/dev-elements/test/gameMetadata.js
+++ b/dev-elements/test/gameMetadata.js
@@ -59,6 +59,7 @@ export default {
     ],
     accesses: ['2,4'],
     exits: ['2,0'],
+    actorsPositions: [[0, 0]],
   },
   numericLineData: {
     statics: [1, null, 5],

--- a/dev-elements/test/gameMetadataDataWithoutBlocks.json
+++ b/dev-elements/test/gameMetadataDataWithoutBlocks.json
@@ -32,7 +32,8 @@
       ["2,0", { "top": true, "bottom": true }]
     ],
     "accesses": ["4,6"],
-    "exits": ["2,0"]
+    "exits": ["2,0"],
+    "actorsPositions": [[0, 0]]
   },
   "numericLineData": {
     "statics": [0, null, 4, 5, 6, 7, 8, 9, 10, 11],

--- a/dev-elements/test/games/maze/easy/first.json
+++ b/dev-elements/test/games/maze/easy/first.json
@@ -16,7 +16,8 @@
       ["2,0", { "top": true, "bottom": true }]
     ],
     "accesses": ["2,4"],
-    "exits": ["2,0"]
+    "exits": ["2,0"],
+    "actorsPositions": [[0, 0]]
   },
   "numericLineData": {
     "statics": [1, null, 5],

--- a/dev-elements/test/games/maze/easy/second.json
+++ b/dev-elements/test/games/maze/easy/second.json
@@ -23,7 +23,8 @@
       ["3,0", { "top": true, "left": true }]
     ],
     "accesses": ["0,4"],
-    "exits": ["3,0"]
+    "exits": ["3,0"],
+    "actorsPositions": [[0, 0]]
   },
   "numericLineData": {
     "statics": [1, 5, null],

--- a/dev-elements/test/games/maze/easy/third.json
+++ b/dev-elements/test/games/maze/easy/third.json
@@ -29,7 +29,8 @@
       ["1,0", { "top": true, "right": true }]
     ],
     "accesses": ["0,4"],
-    "exits": ["1,0"]
+    "exits": ["1,0"],
+    "actorsPositions": [[0, 0]]
   },
   "numericLineData": {
     "statics": [null, 6, 9],

--- a/src/containers/MazeGameContainer.stories.jsx
+++ b/src/containers/MazeGameContainer.stories.jsx
@@ -4,6 +4,7 @@
  *
  * @flow
  */
+/* eslint-disable no-magic-numbers */
 import React from 'react';
 
 import { storiesOf } from 'test/storybook-facades';
@@ -14,4 +15,29 @@ import MazeGameContainer from './MazeGameContainer';
 storiesOf('containers.MazeGameContainer', module)
   .add('first game', () => (
     <MazeGameContainer blocklyData={blocklyData} gameMetadata={gameMetadata} />
-  ));
+  ))
+  .add('multiple exits game', () => {
+    const newGameMetadata = {
+      ...gameMetadata,
+      mazeData: {
+        ...gameMetadata.mazeData,
+        path: [
+          ['2,4', { top: true }],
+          ['2,3', { top: true, bottom: true }],
+          ['2,2', { top: true, bottom: true }],
+          ['2,1', { top: true, bottom: true }],
+          ['2,0', { top: true, bottom: true, right: true }],
+          ['3,0', { top: true, left: true }],
+        ],
+        exits: ['2,0', '3,0'],
+      },
+      numericLineData: {
+        statics: [1, null, null],
+        accesses: [1, 2],
+      },
+    };
+
+    return (
+      <MazeGameContainer blocklyData={blocklyData} gameMetadata={newGameMetadata} />
+    );
+  });

--- a/src/engine/components/mazeGenerator.js
+++ b/src/engine/components/mazeGenerator.js
@@ -13,21 +13,30 @@ import blockGeneratorConfig, { BLOCK_DEFINITIONS, type ActivePathBorders } from 
 const BLOCK_FIRST = 0;
 
 export type MazeData = {|
-  accesses: Array<string>,
-  exits: Array<string>,
   canvas: {|
     height: number,
     width: number,
   |},
+  width: number,
   height: number,
   margin: number,
+  size: number,
   /**
    * The first will define wich blocks are path.
    * The second will define wich borders are wall.
    */
   path: Map<string, ActivePathBorders>,
-  size: number,
-  width: number,
+  accesses: Array<string>,
+  exits: Array<string>,
+  /**
+  * Each pair represents start and end positions for one actor.
+  *
+  * - The first element points to an `accesses` position.
+  * - The second element points to an `exits` position.
+  *
+  * @type {Array<[number, number]>}
+  */
+  actorsPositions: Array<[number, number]>,
 |};
 export type Maze = {|
   view: Container,

--- a/src/engine/components/mazeGenerator.stories.jsx
+++ b/src/engine/components/mazeGenerator.stories.jsx
@@ -23,7 +23,7 @@ mazeData.path = new Map(mazeData.path);
 
 const basicMaze = mazeGenerator(mazeData);
 const simpleNumberMaze = mazeGenerator(mazeData);
-const number = numberGenerator(-TEN, mazeData.accesses[0], mazeData.size, mazeData.margin);
+const number = numberGenerator(-TEN, mazeData.accesses[0], mazeData.exits[0], mazeData.size, mazeData.margin);
 
 storiesOf('engine.components.Maze', module)
   .add('basic Maze', () => (

--- a/src/engine/components/numberGenerator/index.js
+++ b/src/engine/components/numberGenerator/index.js
@@ -29,6 +29,7 @@ const styleRaw = {
 export type NumberActor = {|
   view: Text,
   position: string,
+  finalPosition: string,
   changeActor(number: number): void,
   hasEnteredToNumericLine(void): Promise<void>,
   resetPosition(void): void,
@@ -124,15 +125,21 @@ const changeActorConfig = (
  * This generator returns a new instance of NumberActor.
  *
  * TODO validate number is between valid range.
- * TODO valid position format.
  *
- * @param  {number} number   what number will be rendered. Valid values: [-99, 99].
- * @param  {string} position Follows the format 'x,y'.
- * @param  {number} size     The size of a block used as relative value
- * @param  {number} margin   size of block's margin
- * @return {NumberActor}     Used for animate a number
+ * @param  {number} number        What number will be rendered. Valid values: [-99, 99].
+ * @param  {string} position      Follows the format 'x,y'.
+ * @param  {string} finalPosition Follows the format 'x,y'.
+ * @param  {number} size          The size of a block used as relative value
+ * @param  {number} margin        Size of block's margin
+ * @return {NumberActor}          Used for animate a number
  */
-const numberGenerator = (number: number, position: string, size: number, margin: number): NumberActor => {
+const numberGenerator = (
+  number: number,
+  position: string,
+  finalPosition: string,
+  size: number,
+  margin: number,
+): NumberActor => {
   const style = new TextStyle({
     ...styleRaw,
     fontSize: size / HALF + size / EIGHT,
@@ -148,6 +155,7 @@ const numberGenerator = (number: number, position: string, size: number, margin:
   return {
     view,
     position,
+    finalPosition,
     changeActor: changeActorConfig(view),
     hasEnteredToNumericLine: hasEnteredToNumericLineConfig(view, size, margin),
     resetPosition: resetPositionConfig(view, initialPosition, size, margin),

--- a/src/engine/components/numberGenerator/index.stories.jsx
+++ b/src/engine/components/numberGenerator/index.stories.jsx
@@ -25,10 +25,10 @@ const MARGINS = {
   negativeOne: 30,
   negativeTen: 40,
 };
-const one = numberGenerator(ONE, POSITION, SIZES.one, MARGINS.one).view;
-const ten = numberGenerator(TEN, POSITION, SIZES.ten, MARGINS.ten).view;
-const negativeOne = numberGenerator(-ONE, POSITION, SIZES.negativeOne, MARGINS.negativeOne).view;
-const negativeTen = numberGenerator(-TEN, POSITION, SIZES.negativeTen, MARGINS.negativeTen).view;
+const one = numberGenerator(ONE, POSITION, POSITION, SIZES.one, MARGINS.one).view;
+const ten = numberGenerator(TEN, POSITION, POSITION, SIZES.ten, MARGINS.ten).view;
+const negativeOne = numberGenerator(-ONE, POSITION, POSITION, SIZES.negativeOne, MARGINS.negativeOne).view;
+const negativeTen = numberGenerator(-TEN, POSITION, POSITION, SIZES.negativeTen, MARGINS.negativeTen).view;
 
 storiesOf('engine.components.Number', module)
   .add('one digit', () => (

--- a/src/engine/components/numberGenerator/index.test.js
+++ b/src/engine/components/numberGenerator/index.test.js
@@ -10,12 +10,12 @@ describe('engine > components > numberGenerator', () => {
   it('should update its position acording to the new position', async () => {
     const rawNumber = 3;
     const initPosition = '1,1';
+    const newPosition = '2,2';
     const size = 64;
     const margin = 10;
-    const number = numberGenerator(rawNumber, initPosition, size, margin);
+    const number = numberGenerator(rawNumber, initPosition, newPosition, size, margin);
     const initX = number.view.x;
     const initY = number.view.y;
-    const newPosition = '2,2';
 
     await number.updatePosition(newPosition);
 
@@ -29,12 +29,13 @@ describe('engine > components > numberGenerator', () => {
     expect(number.view.x).toBe(initX);
     expect(number.view.y).toBe(initY);
   });
-  it('should update its position to undefined on enter to numeric line', async () => {
+  it('should update its position to undefined when enter to numeric line', async () => {
     const rawNumber = 3;
     const initPosition = '1,1';
+    const finalPosition = '1,1';
     const size = 64;
     const margin = 10;
-    const number = numberGenerator(rawNumber, initPosition, size, margin);
+    const number = numberGenerator(rawNumber, initPosition, finalPosition, size, margin);
     const initX = number.view.x;
     const initY = number.view.y;
 
@@ -49,9 +50,10 @@ describe('engine > components > numberGenerator', () => {
     async () => {
       const rawNumber = 3;
       const initPosition = '1,1';
+      const finalPosition = '1,1';
       const size = 64;
       const margin = 10;
-      const number = numberGenerator(rawNumber, initPosition, size, margin);
+      const number = numberGenerator(rawNumber, initPosition, finalPosition, size, margin);
 
       await number.hasEnteredToNumericLine();
 

--- a/src/engine/components/numericLineGenerator/index.stories.jsx
+++ b/src/engine/components/numericLineGenerator/index.stories.jsx
@@ -17,6 +17,7 @@ import lineGenerator from './lineGenerator';
 
 import numericLineGenerator from './index';
 
+const POSITION = '0,0';
 const SIZE = 64;
 const WIDTH_NUMERIC_LINE = 960;
 const HEIGHT_NUMERIC_LINE = 300;
@@ -81,7 +82,7 @@ storiesOf('engine.components.numericLine', module)
   })
   .add('line with an animated number', () => {
     const line = lineGenerator([null, null, null, null, null, null, null, null], SIZE, TEN);
-    const ten = numberGenerator(TEN, '0,0', SIZE, TEN);
+    const ten = numberGenerator(TEN, POSITION, POSITION, SIZE, TEN);
 
     line.view.x = 32;
     line.view.y = 28;
@@ -124,7 +125,7 @@ storiesOf('engine.components.numericLine', module)
   .add('numeric line with animated and static numbers', () => {
     // eslint-disable-next-line no-magic-numbers
     const numericLine = numericLineGenerator([1, 2, 3, 4, 5, 6, 7, 8, 9, null], SIZE, TEN);
-    const ten = numberGenerator(TEN, '0,0', SIZE, TEN);
+    const ten = numberGenerator(TEN, POSITION, POSITION, SIZE, TEN);
 
     (async () => {
       await wait(500); // eslint-disable-line no-magic-numbers

--- a/src/engine/containers/mazeEngineGenerator.test.js
+++ b/src/engine/containers/mazeEngineGenerator.test.js
@@ -44,6 +44,10 @@ describe('engine > containers > mazeEngineGenerator', () => {
       ...mazeData,
       accesses: [mazeData.accesses[0], mazeData.accesses[0]],
       exits: [mazeData.exits[0], mazeData.exits[0]],
+      actorsPositions: [
+        [0, 0],
+        [1, 1],
+      ],
     };
     const newNumericLineData = {
       statics: [1, null, 5, null, 9],
@@ -79,6 +83,7 @@ describe('engine > containers > mazeEngineGenerator', () => {
       path: new Map([['0,0', {}], ['1,0', {}]]),
       accesses: ['0,0'],
       exits: ['1,0'],
+      actorsPositions: [[0, 0]],
     };
     const newNumericLineData = {
       statics: [null, 6, 9],
@@ -97,6 +102,65 @@ describe('engine > containers > mazeEngineGenerator', () => {
       expect(errors).toBeInstanceOf(Array);
       expect(errors.length).toBe(ONE);
       expect(errors[0].name).toBe('MazePathError');
+
+      return;
+    }
+    expect('true').toBe('not evaluated');
+  });
+  it('should be possible to create a maze with 1-actor:n-exits', async () => {
+    const newMazeData = {
+      canvas: { height: 500, width: 450 },
+      width: 5,
+      height: 5,
+      margin: 10,
+      size: 64,
+      path: new Map([['0,0', {}], ['1,0', {}]]),
+      accesses: ['0,0'],
+      exits: ['1,0'],
+      actorsPositions: [[0, 0]],
+    };
+    const newNumericLineData = {
+      statics: [null, 6, null],
+      accesses: [0, 1],
+    };
+    const mazeEngine = mazeEngineGenerator(newMazeData, newNumericLineData);
+
+    expect(mazeEngine).not.toBeUndefined();
+  });
+  it('should throw a MazeWrongExitError if the actor leaves at the wrong exit', async () => {
+    const newMazeData = {
+      canvas: { height: 500, width: 450 },
+      width: 5,
+      height: 5,
+      margin: 10,
+      size: 64,
+      path: new Map([
+        ['0,0', { right: true }],
+        ['1,0', { left: true }],
+      ]),
+      accesses: ['0,0'],
+      exits: ['1,0', '1,1'],
+      actorsPositions: [
+        [0, 1],
+      ],
+    };
+    const newNumericLineData = {
+      statics: [null, 6, null],
+      accesses: [0, 1],
+    };
+    const mazeEngine = mazeEngineGenerator(newMazeData, newNumericLineData);
+    const actions = new Map();
+
+    actions.set(ACTOR, [
+      blockNames.MOVE_RIGHT,
+    ]);
+
+    try {
+      await mazeEngine.excecuteSetOfInstructions(actions);
+    } catch (errors) {
+      expect(errors).toBeInstanceOf(Array);
+      expect(errors.length).toBe(ONE);
+      expect(errors[0].name).toBe('MazeWrongExitError');
 
       return;
     }

--- a/src/engine/helpers/errors.js
+++ b/src/engine/helpers/errors.js
@@ -24,3 +24,11 @@ export function MazeExitError(actor: number) {
   this.message = 'This position is not an exit';
   this.stack = (new Error()).stack;
 }
+
+export function MazeWrongExitError(actor: number) {
+  this.name = MazeWrongExitError.name;
+  this.actor = actor;
+  // FIXME actor value is the actor ID, not the actual actor
+  this.message = `The number ${actor} has left at the wrong exit`;
+  this.stack = (new Error()).stack;
+}


### PR DESCRIPTION
At the end, it was necessary to add a new property to the `gameMetadata`. Why? Because it wasn't possible to determine which exit was for which actor, even having only one actor.

Without the new property, it was ALWAYS going to be the first exit the actor's exit.

The good new is that this new property will open new possibilities 😄.