### PR TITLE
[Fix #13] Add difficulty range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## HEAD
 
+- 🚀 [2017-05-10] `engine/helpers/randomConfigurations`: update to v1.1.0.
+  - `randomizeActorsConfig`:
+    - 🚀 New parameter: `difficulty`: is a string that have 3 possible values. It's used to select which range is the one who needs.
 - 🚀 [2017-05-10] `engine/containers/mazeEngineGenerator`: update to v3.2.0.
   - 🚀 New parameter: `difficulty`: is a string that have 3 possible values and it's used by `randomConfigurations@randomizeActorsConfig`.
 - 🚀 [2017-05-09] `engine/containers/mazeEngineGenerator`: update to v3.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- 🚀 [2017-05-10] `engine/containers/mazeEngineGenerator`: update to v3.2.0.
+  - 🚀 New parameter: `difficulty`: is a string that have 3 possible values and it's used by `randomConfigurations@randomizeActorsConfig`.
 - 🚀 [2017-05-09] `engine/containers/mazeEngineGenerator`: update to v3.1.0.
   - 🚀 Add new validation with new error type (`MazeWrongExitError`) for `numberHasLeftMaze`. This will be thrown if the actual actor's exit is wrong.
   - 🚀 Update `handleResetGame` to match the new `gameMetadata` prop & how actor-exit relation works now.

--- a/dev-elements/test/gameMetadata.js
+++ b/dev-elements/test/gameMetadata.js
@@ -41,6 +41,7 @@ export const blocklyData = {
 };
 
 export default {
+  difficulty: 'easy',
   mazeData: {
     canvas: {
       height: 500,

--- a/dev-elements/test/gameMetadataDataWithoutBlocks.json
+++ b/dev-elements/test/gameMetadataDataWithoutBlocks.json
@@ -1,4 +1,5 @@
 {
+  "difficulty": "easy",
   "mazeData": {
     "width": 15,
     "height": 7,

--- a/dev-elements/test/games/maze/easy/001.json
+++ b/dev-elements/test/games/maze/easy/001.json
@@ -1,4 +1,5 @@
 {
+  "difficulty": "easy",
   "mazeData": {
     "canvas": {
       "height": 500,

--- a/dev-elements/test/games/maze/easy/002.json
+++ b/dev-elements/test/games/maze/easy/002.json
@@ -1,4 +1,5 @@
 {
+  "difficulty": "easy",
   "mazeData": {
     "canvas": {
       "height": 500,

--- a/dev-elements/test/games/maze/easy/003.json
+++ b/dev-elements/test/games/maze/easy/003.json
@@ -1,4 +1,5 @@
 {
+  "difficulty": "easy",
   "mazeData": {
     "canvas": {
       "height": 500,

--- a/dev-elements/test/games/maze/easy/004.json
+++ b/dev-elements/test/games/maze/easy/004.json
@@ -1,4 +1,5 @@
 {
+  "difficulty": "easy",
   "mazeData": {
     "canvas": {
       "height": 500,

--- a/src/containers/MazeGameContainer.jsx
+++ b/src/containers/MazeGameContainer.jsx
@@ -11,7 +11,10 @@ import styled from 'styled-components';
 import { type ActorsToActions } from 'blockly/executorGenerator';
 import BlocklyApp, { type BlocklyData } from 'components/BlocklyApp';
 import { HALF } from 'constants/numbers';
-import mazeEngineGenerator, { type Engine } from 'engine/containers/mazeEngineGenerator';
+import mazeEngineGenerator, {
+  type Engine,
+  type GameDifficulty,
+} from 'engine/containers/mazeEngineGenerator';
 import { type MazeData } from 'engine/components/mazeGenerator';
 import { type ActivePathBorders } from 'engine/components/blockGeneratorConfig';
 import { type NumericLineData } from 'engine/components/numericLineGenerator';
@@ -32,6 +35,7 @@ type RawMazeData = {|
 type Props = {|
   blocklyData: BlocklyData,
   gameMetadata: {|
+    difficulty: GameDifficulty,
     mazeData: RawMazeData,
     numericLineData: NumericLineData,
   |},
@@ -51,8 +55,9 @@ export default class MazeGameContainer extends React.Component {
       ...props.gameMetadata.mazeData,
       path: new Map(props.gameMetadata.mazeData.path),
     };
+    const { numericLineData, difficulty } = props.gameMetadata;
 
-    this.engine = mazeEngineGenerator(mazeData, props.gameMetadata.numericLineData);
+    this.engine = mazeEngineGenerator(mazeData, numericLineData, difficulty);
   }
 
   componentDidMount() {

--- a/src/engine/containers/mazeEngineGenerator.js
+++ b/src/engine/containers/mazeEngineGenerator.js
@@ -103,6 +103,7 @@ const handleResetGameConfig = (
   });
 };
 
+export type GameDifficulty = 'easy' | 'normal' | 'hard';
 export type Engine = {|
   view: Container,
   excecuteSetOfInstructions(instructions: ActorsToActions): Promise<void>,
@@ -111,6 +112,7 @@ export type Engine = {|
 export default function mazeEngineGenerator(
   mazeData: MazeData,
   numericLineData: NumericLineData,
+  difficulty: GameDifficulty,
 ): Engine {
   const view = new Container();
   const numericLine = numericLineGenerator(
@@ -123,6 +125,7 @@ export default function mazeEngineGenerator(
   const randomizeActors = randomizeActorsConfig(
     numericLineData.statics,
     numericLineData.accesses,
+    difficulty,
   );
   const randomActors = randomizeActors();
   const numbers: Array<NumberActor> = mazeData.actorsPositions.map((actorPositions) => {

--- a/src/engine/containers/mazeEngineGenerator.stories.jsx
+++ b/src/engine/containers/mazeEngineGenerator.stories.jsx
@@ -16,13 +16,13 @@ import mazeEngineGenerator from './mazeEngineGenerator';
 
 const WIDTH = 1300;
 const HEIGHT = 660;
-const { mazeData, numericLineData } = gameMetadataDataWithoutBlocks;
+const { mazeData, numericLineData, difficulty } = gameMetadataDataWithoutBlocks;
 
 mazeData.path = new Map(mazeData.path);
 
 storiesOf('engine.containers.mazeEngineGenerator', module)
   .add('simple mazeEngine', () => {
-    const mazeEngine = mazeEngineGenerator(mazeData, numericLineData);
+    const mazeEngine = mazeEngineGenerator(mazeData, numericLineData, difficulty);
     const actions = new Map();
     const ACTOR = 0;
 

--- a/src/engine/containers/mazeEngineGenerator.test.js
+++ b/src/engine/containers/mazeEngineGenerator.test.js
@@ -13,13 +13,13 @@ import mazeEngineGenerator from './mazeEngineGenerator';
 const ACTOR = 0;
 const ONE = 1;
 const TWO = 2;
-const { mazeData, numericLineData } = gameMetadataDataWithoutBlocks;
+const { mazeData, numericLineData, difficulty } = gameMetadataDataWithoutBlocks;
 
 mazeData.path = new Map(mazeData.path);
 
 describe('engine > containers > mazeEngineGenerator', () => {
   it('should parse an array of correct actions and return a response', async () => {
-    const mazeEngine = mazeEngineGenerator(mazeData, numericLineData);
+    const mazeEngine = mazeEngineGenerator(mazeData, numericLineData, difficulty);
     const actions = new Map();
 
     actions.set(ACTOR, [
@@ -53,7 +53,7 @@ describe('engine > containers > mazeEngineGenerator', () => {
       statics: [1, null, 5, null, 9],
       accesses: [1, 3],
     };
-    const mazeEngine = mazeEngineGenerator(newMazeData, newNumericLineData);
+    const mazeEngine = mazeEngineGenerator(newMazeData, newNumericLineData, difficulty);
     const actions = new Map();
 
     actions.set(ACTOR, [
@@ -89,7 +89,7 @@ describe('engine > containers > mazeEngineGenerator', () => {
       statics: [null, 6, 9],
       accesses: [0],
     };
-    const mazeEngine = mazeEngineGenerator(newMazeData, newNumericLineData);
+    const mazeEngine = mazeEngineGenerator(newMazeData, newNumericLineData, difficulty);
     const actions = new Map();
 
     actions.set(ACTOR, [
@@ -123,7 +123,7 @@ describe('engine > containers > mazeEngineGenerator', () => {
       statics: [null, 6, null],
       accesses: [0, 1],
     };
-    const mazeEngine = mazeEngineGenerator(newMazeData, newNumericLineData);
+    const mazeEngine = mazeEngineGenerator(newMazeData, newNumericLineData, difficulty);
 
     expect(mazeEngine).not.toBeUndefined();
   });
@@ -148,7 +148,7 @@ describe('engine > containers > mazeEngineGenerator', () => {
       statics: [null, 6, null],
       accesses: [0, 1],
     };
-    const mazeEngine = mazeEngineGenerator(newMazeData, newNumericLineData);
+    const mazeEngine = mazeEngineGenerator(newMazeData, newNumericLineData, difficulty);
     const actions = new Map();
 
     actions.set(ACTOR, [

--- a/src/engine/helpers/randomConfigurations.js
+++ b/src/engine/helpers/randomConfigurations.js
@@ -5,9 +5,15 @@
  * @flow
  */
 import { ONE } from 'constants/numbers';
+import { type GameDifficulty } from 'engine/containers/mazeEngineGenerator';
 
-const MIN = 0;
-const MAX = 9;
+/* eslint-disable no-magic-numbers */
+const RANGES = {
+  easy: [0, 9],
+  normal: [0, 99],
+  hard: [-99, 99],
+};
+/* eslint-enable */
 
 function getRandomInt(rawMin: number, max: number) {
   const min = rawMin + ONE;
@@ -17,10 +23,18 @@ function getRandomInt(rawMin: number, max: number) {
 
 // FIXME when add another export element
 // eslint-disable-next-line import/prefer-default-export
-export const randomizeActorsConfig = (statics: Array<number | null>, accesses: Array<number>) => {
+export const randomizeActorsConfig = (
+  statics: Array<number | null>,
+  accesses: Array<number>,
+  difficulty: GameDifficulty,
+) => {
   const definedRanges = accesses.map((actorPosition) => ({
-    min: typeof statics[actorPosition - ONE] === 'number' ? statics[actorPosition - ONE] : MIN - ONE,
-    max: typeof statics[actorPosition + ONE] === 'number' ? statics[actorPosition + ONE] : MAX + ONE,
+    min: typeof statics[actorPosition - ONE] === 'number'
+        ? statics[actorPosition - ONE]
+        : RANGES[difficulty][0] - ONE,
+    max: typeof statics[actorPosition + ONE] === 'number'
+        ? statics[actorPosition + ONE]
+        : RANGES[difficulty][1] + ONE,
   }));
 
   return () => (

--- a/src/engine/helpers/randomConfigurations.test.js
+++ b/src/engine/helpers/randomConfigurations.test.js
@@ -7,12 +7,14 @@
 /* eslint-disable no-magic-numbers, */
 import { randomizeActorsConfig } from './randomConfigurations';
 
+const EASY = 'easy';
+
 describe('helpers/randomConfigurations', () => {
   describe('randomizeActorConfig', () => {
     it('should return an appropriate number for each empty position on the numeric line', () => {
       const statics = [0, null, 5];
       const accesses = [1];
-      const result = randomizeActorsConfig(statics, accesses)();
+      const result = randomizeActorsConfig(statics, accesses, EASY)();
 
       expect(result).toBeInstanceOf(Array);
       expect(result.length).toBe(accesses.length);
@@ -22,7 +24,7 @@ describe('helpers/randomConfigurations', () => {
     it('should always return the same number if the diff between min and max is eq 2', () => {
       const statics = [1, null, 3, null, 5];
       const accesses = [1, 3];
-      const result = randomizeActorsConfig(statics, accesses)();
+      const result = randomizeActorsConfig(statics, accesses, EASY)();
 
       expect(result[0]).toBe(statics[0] + 1);
       expect(result[1]).toBe(statics[4] - 1);
@@ -30,7 +32,7 @@ describe('helpers/randomConfigurations', () => {
     it('should work as expected when the `null` are defined at first and last position', () => {
       const statics = [null, 5, null];
       const accesses = [0, 2];
-      const result = randomizeActorsConfig(statics, accesses)();
+      const result = randomizeActorsConfig(statics, accesses, EASY)();
 
       expect(typeof result[0]).toBe('number');
       expect(typeof result[1]).toBe('number');


### PR DESCRIPTION
Adds a difficulty property to mazeMetaData structure that it will be used by `randomConfigurations@randomizeActorsConfig`.