### PR TITLE
🐛 Update `mazeEngineGenerator` to v4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- 🐛 [2017-06-08] `engine/containers/mazeEngineGenerator`: update to v4.3.1.
+  - 🐛 Fix falsy `actorExitIdx` error.
 - 🐛 [2017-06-07] `engine/errors`: update to v2.0.1.
   - 🐛 Remove an `unidentified` property being passed to `sweetalert2`.
 - 🚀 [2017-06-07] `engine/containers/mazeEngineGenerator`: update to v4.3.0.

--- a/dev-elements/test/games/maze/easy/004.json
+++ b/dev-elements/test/games/maze/easy/004.json
@@ -34,7 +34,7 @@
       ["5,0", { "top": true, "right": true }]
     ],
     "access": "3,1",
-    "exits": ["1,0"],
+    "exits": ["1,0", "5,0"],
     "actorExitIdx": 0
   },
   "numericLineData": {

--- a/src/engine/containers/mazeEngineGenerator.js
+++ b/src/engine/containers/mazeEngineGenerator.js
@@ -166,7 +166,9 @@ export default function mazeEngineGenerator(
     difficulty,
   );
   const randomActor = randomizeActor();
-  const actorExitIdx = mazeData.actorExitIdx || getRandomInt(ZERO, randomActor.length);
+  const actorExitIdx = mazeData.actorExitIdx !== undefined
+                      ? mazeData.actorExitIdx
+                      : getRandomInt(ZERO, randomActor.length);
   const number = numberGenerator(
     randomActor[actorExitIdx],
     mazeData.access,


### PR DESCRIPTION
- 🐛 [2017-06-08] `engine/containers/mazeEngineGenerator`: update to v4.3.1.
  - 🐛 Fix falsy `actorExitIdx` error.